### PR TITLE
Exit 0 on EOF

### DIFF
--- a/src/cronolog.c
+++ b/src/cronolog.c
@@ -315,7 +315,7 @@ main(int argc, char **argv)
 	    n_bytes_read = read(0, read_buf, sizeof read_buf);
 	    if (n_bytes_read == 0)
 	    {
-		exit(3);
+		exit(0);
 	    }
 	    if (n_bytes_read < 0)
 	    {


### PR DESCRIPTION
Cronolog for years has exited with a status code of 3 when it encounters an EOF condition on stdin.  EOF is a normal condition when the process writing to cronolog closes its log file or exits.  If cronolog is being used as part of a pipe in a scripted command, it's impossible to determine if the pipe was successful because of the non-zero status.

This pull request simply changes the exit code on EOF to 0 indicating a successful completion.